### PR TITLE
Today's date highlight selected

### DIFF
--- a/lib/src/date_item.dart
+++ b/lib/src/date_item.dart
@@ -83,9 +83,14 @@ class __DateItemState extends State<DateItem> {
 
             /// Check and set [Background] of today
             if (compareDate(widget.date, widget.today)) {
+              if (compareDate(widget.date, dateSelected)) {
+                _defaultBackgroundColor = widget.pressedBackgroundColor;
+                print('temp');
+              }
               _defaultBackgroundColor = widget.todayBackgroundColor;
+              print('temp2');
             } else if (!data.hasError && data.hasData) {
-              final DateTime? dateSelected = data.data;
+              
               if (compareDate(widget.date, dateSelected)) {
                 _defaultBackgroundColor = widget.pressedBackgroundColor;
                 _defaultTextStyle = widget.pressedDateStyle;


### PR DESCRIPTION
When you picked today's date, it remained the default color for today. Add the color swap to pressed color so that when you pick today, it shows the same styling as the usual selected dates.